### PR TITLE
Add braket package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
                   standalone
                   xcolor
                   xetex
+                  braket
                   ;
               })
             ];

--- a/src/latex.rs
+++ b/src/latex.rs
@@ -56,6 +56,7 @@ async fn render_to_png(width: ImageWidth, input: &str) -> anyhow::Result<PngResu
         \usepackage{amsmath,amssymb}
         \usepackage{xcolor}
         \usepackage{bussproofs}
+        \usepackage{braket}
         \definecolor{discordbg}{HTML}{313338}
         \begin{document}
         \color{white}


### PR DESCRIPTION
I added the [braket latex package](https://www.ctan.org/pkg/braket) to allow using `\set{…}`, `|` instead of `\mid` or `\vert`, and other commands :)