### PR TITLE
Increase vertical margin

### DIFF
--- a/src/typst.rs
+++ b/src/typst.rs
@@ -146,7 +146,8 @@ impl World for DummyWorld {
 
 pub fn render_to_png(typst: String) -> anyhow::Result<Vec<u8>> {
     let typst = [
-        "#set page(width: 11.5cm, height: auto, margin: 0.1cm, fill: rgb(\"#313338\"))",
+        "#set page(width: 11.5cm, height: auto, margin: (x: 1mm, y: 2mm))",
+        "#set page(fill: rgb(\"#313338\"))", // Discord background color
         "#set text(white)",
         &typst,
     ]


### PR DESCRIPTION
The problem:

![image](https://github.com/kitmatheinfo/latexfogel/assets/11077553/8bd2405d-475e-438f-b685-2558375f6bfb)

![image](https://github.com/kitmatheinfo/latexfogel/assets/11077553/19776099-5adc-4101-b6ee-fd827f2e91a3)

By increasing the vertical margin, inline math sub- and superscript like `$B_(1/2)$` or even an extreme example like `$integral_(integral_integral)^(integral^integral)$` stays fully visible.

While the horizontal margin could probably be reduced to 0mm, I'd rather keep it at 1mm to be on the safe side.