### PR TITLE
Include typst packages in binary

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build
         if: github.event_name == 'pull_request'
-        run: nix build --ignore-environment --keep PATH --keep IMAGE_NAME
+        run: nix build .#docker
 
       - name: Build and publish docker image
         if: github.event_name != 'pull_request'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "typst-packages"]
+	path = typst-packages
+	url = https://github.com/typst/packages.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "typst-packages"]
-	path = typst-packages
-	url = https://github.com/typst/packages.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,21 +833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,19 +1105,6 @@ dependencies = [
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1461,12 +1433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,24 +1562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,48 +1627,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "openssl"
-version = "0.10.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.49",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1858,12 +1768,6 @@ checksum = "e2e0f8ad4c197db38125b880c3c44544788665c7d5f4c42f5a35da44bca1a712"
 dependencies = [
  "ttf-parser",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plist"
@@ -2108,17 +2012,16 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2126,7 +2029,6 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
@@ -2242,6 +2144,18 @@ dependencies = [
  "ring 0.17.8",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2871,16 +2785,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,12 +3287,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
+name = "include_dir"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1441,7 @@ dependencies = [
  "env_logger",
  "fontdb",
  "image",
+ "include_dir",
  "log",
  "poise",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,25 +1331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
-name = "include_dir"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,7 +1422,6 @@ dependencies = [
  "env_logger",
  "fontdb",
  "image",
- "include_dir",
  "log",
  "poise",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ fontdb = "0.16.2"
 image = "0.24.7"
 log = "0.4.20"
 poise = "0.5.6"
-reqwest = "0.11.20"
+reqwest = { version = "0.11.20", default-features = false, features = [
+    "rustls-tls-native-roots",
+] }
 tempfile = "3.8.0"
 tokio = { version = "1.32.0", features = ["full"] }
 typst = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ comemo = "0.4.0"
 env_logger = "0.10.0"
 fontdb = "0.16.2"
 image = "0.24.7"
+include_dir = "0.7.3"
 log = "0.4.20"
 poise = "0.5.6"
 reqwest = { version = "0.11.20", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ comemo = "0.4.0"
 env_logger = "0.10.0"
 fontdb = "0.16.2"
 image = "0.24.7"
-include_dir = "0.7.3"
 log = "0.4.20"
 poise = "0.5.6"
 reqwest = { version = "0.11.20", default-features = false, features = [

--- a/flake.lock
+++ b/flake.lock
@@ -39,7 +39,24 @@
     "root": {
       "inputs": {
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "typst-packages": "typst-packages"
+      }
+    },
+    "typst-packages": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715767920,
+        "narHash": "sha256-gvy1q4ul3hpiwc1Sa6ppXPGL69qYHRHriG5KKNDemQA=",
+        "owner": "typst",
+        "repo": "packages",
+        "rev": "d06d87c0c46d91ccdca6b9913a85021ad4bec90e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "typst",
+        "repo": "packages",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,11 @@
+# IMPORTANT:
+#
+# When using the flake as input, include `?submodules=1` at the end of the flake
+# URL. This also applies when building the flake, meaning you have to use the
+# following command:
+#
+# $ nix build '.?submodules=1'
+
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
           latexfogel = naersk'.buildPackage
             {
               root = ./.;
-              nativeBuildInputs = with pkgs; [ pkg-config openssl graphite2 icu freetype fontconfig ];
+              nativeBuildInputs = with pkgs; [ pkg-config graphite2 icu freetype fontconfig ];
             };
           default = latexfogel;
           docker = pkgs.dockerTools.buildLayeredImage {

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,12 @@
 
     naersk.url = "github:nix-community/naersk";
     naersk.inputs.nixpkgs.follows = "nixpkgs";
+
+    typst-packages.url = "github:typst/packages";
+    typst-packages.flake = false;
   };
 
-  outputs = { self, nixpkgs, naersk }:
+  outputs = { self, nixpkgs, naersk, typst-packages }:
     let forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
     in rec {
       packages = forAllSystems (system:
@@ -62,6 +65,7 @@
               WorkingDir = "/";
               Env = [
                 "FONTCONFIG_FILE=${pkgs.makeFontsConf { fontDirectories = [ texliveCombined.fonts pkgs.noto-fonts pkgs.noto-fonts-color-emoji ]; }}"
+                "TYPST_PACKAGES=${typst-packages}/packages"
                 "HOME=/tmp"
               ];
             };

--- a/src/typst.rs
+++ b/src/typst.rs
@@ -133,11 +133,13 @@ impl World for DummyWorld {
 
     fn file(&self, id: FileId) -> FileResult<Bytes> {
         let Some(package) = id.package() else {
-            return Err(FileError::AccessDenied);
+            return Err(FileError::Other(Some(
+                "only packages can be imported".into(),
+            )));
         };
 
         let mut path: PathBuf = std::env::var("TYPST_PACKAGES")
-            .map_err(|_| FileError::AccessDenied)?
+            .map_err(|_| FileError::Other(Some("can't find my packages D:".into())))?
             .into();
 
         // Translate package spec to path in packages repo.


### PR DESCRIPTION
The https://typst.app/universe packages come from https://github.com/typst/packages, which is now included in the binary and provided to the typst code.